### PR TITLE
Update MATIC ticker to POL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Supported coins:
 - Litecoin (LTC)
 - Monero (XMR)
 - Optimism (OP) and Optimism tokens
-- Polygon (MATIC) and Polygon tokens
+- Polygon (POL) and Polygon tokens
 - Solana (SOL) and SPL tokens
 - Stellar (XLM)
 - TRON (TRX) and TRC20 tokens


### PR DESCRIPTION
MATIC has been upgraded to POL as the network token for Polygon
https://polygon.technology/blog/matic-to-pol-migration-is-now-live-everything-you-need-to-know